### PR TITLE
Remove explicit libssl installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN apt update && \
         ca-certificates=20210119 \
         at=3.1.23-1.1 \
         libsqlite3-0=3.34.1-3 \
-        libssl1.1=1.1.1n-0+deb11u1 \
         libass9=1:0.15.0-2 \
         libbluray2=1:1.2.1-4+deb11u1 \
         libdrm-intel1=2.4.104-1 \


### PR DESCRIPTION
Fixes #1. libssl1.1 is already shipped in the debian:stable-20220527-slim image anyway.